### PR TITLE
增加远行商人实时商品查询功能

### DIFF
--- a/env.toml.example
+++ b/env.toml.example
@@ -82,6 +82,7 @@ apod_group_id = []
 earth_now_group_id = []
 news_summary_group_id = []
 earthquake_group_id = []
+nrc_merchant_group_id = []
 
 [database]
 query_message_numbers = 100

--- a/plugins/clockwork/__init__.py
+++ b/plugins/clockwork/__init__.py
@@ -54,7 +54,31 @@ async def init_task_system():
     # 4. 同步群组配置到 EnvConfig
     await task_manager.initialize()
 
-    # 5. 注册 V3 Dreaming 记忆整理（每天凌晨 4:00）
+    # 5. 注册 NRC 远行商人商品预警（每天 8:00、12:00、16:00、20:00）
+    try:
+        await task_manager.register_task(
+            job_id="nrc_merchant_alert",
+            name="远行商人商品预警",
+            handler_module="plugins.clockwork.task_handlers",
+            handler_function="nrc_merchant_alert",
+            trigger_type="cron",
+            trigger_args={"hour": "8,12,16,20", "minute": "0"},
+            group_ids=EnvConfig.NRC_MERCHANT_GROUP_ID,
+            description="每天定时检测远行商人是否上架目标商品（国王球、棱镜球、炫彩精灵蛋、祝福项坠、首领血脉秘药），有则推送提醒",
+            metadata=ScheduledTaskMetadata(
+                job_id="nrc_merchant_alert",
+                owner_user_id="system",
+                target_type="group",
+                target_id=",".join(str(g) for g in EnvConfig.NRC_MERCHANT_GROUP_ID) if EnvConfig.NRC_MERCHANT_GROUP_ID else "0",
+                prompt="",
+                created_from="system",
+            ),
+        )
+        logger.info("NRC 远行商人商品预警已注册（cron: 8,12,16,20:00 Asia/Shanghai）")
+    except Exception as exc:
+        logger.warning(f"注册 NRC 远行商人任务失败（可能已存在）: {exc}")
+
+    # 6. 注册 V3 Dreaming 记忆整理（每天凌晨 4:00）
     try:
         from utils.dreaming_pipeline import build_dreaming_task_config
 

--- a/plugins/clockwork/__init__.py
+++ b/plugins/clockwork/__init__.py
@@ -54,11 +54,11 @@ async def init_task_system():
     # 4. 同步群组配置到 EnvConfig
     await task_manager.initialize()
 
-    # 5. 注册 NRC 远行商人商品预警（每天 8:00、12:00、16:00、20:00）
+    # 5. 注册 NRC 远行商人商品提醒推送（每天 8:00、12:00、16:00、20:00）
     try:
         await task_manager.register_task(
             job_id="nrc_merchant_alert",
-            name="远行商人商品预警",
+            name="远行商人商品提醒推送",
             handler_module="plugins.clockwork.task_handlers",
             handler_function="nrc_merchant_alert",
             trigger_type="cron",
@@ -74,7 +74,7 @@ async def init_task_system():
                 created_from="system",
             ),
         )
-        logger.info("NRC 远行商人商品预警已注册（cron: 8,12,16,20:00 Asia/Shanghai）")
+        logger.info("NRC 远行商人商品提醒推送已注册（cron: 8,12,16,20:00 Asia/Shanghai）")
     except Exception as exc:
         logger.warning(f"注册 NRC 远行商人任务失败（可能已存在）: {exc}")
 

--- a/plugins/clockwork/task_handlers.py
+++ b/plugins/clockwork/task_handlers.py
@@ -484,7 +484,7 @@ async def happy_new_year(**kwargs):
 async def nrc_merchant_alert(**kwargs):
     """远行商人商品提醒推送 - 每天8:00、12:00、16:00、20:00推送。
 
-    检测目标商品是否上架，有则发提醒文本 + 货架图片，无则静默跳过。
+    每次推送货架图片；检测到目标商品上架时，先发提醒文本再发图片。
     """
     from tools.NRCmerchant_current import ALERT_TARGET_ITEMS, _load_css, _render_html, fetch_merchant_data
 
@@ -495,31 +495,25 @@ async def nrc_merchant_alert(**kwargs):
 
     items = data.get("items", [])
     hits = [item for item in items if item.get("name") in ALERT_TARGET_ITEMS]
-    if not hits:
-        logger.debug("NRC 商人提醒推送：无目标商品上架，静默跳过")
-        return
-
-    hit_names = "、".join(item["name"] for item in hits)
-    alert_text = f"⚠️ 远行商人上架提醒：{hit_names} 已上架！"
+    hit_names = "、".join(item["name"] for item in hits) if hits else ""
 
     html = _render_html(data)
     css = _load_css()
     image = await html_to_image(html, css=css, width=480)
 
-    msg_text = UniMessage.text(alert_text)
-    msg_img = UniMessage.image(raw=image)
-
     groups_sent: list[int] = []
     for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
         try:
-            await msg_text.send(target=Target.group(str(group)))
-            await msg_img.send(target=Target.group(str(group)))
+            if hits:
+                await UniMessage.text(f"⚠️ 远行商人上架提醒：{hit_names} 已上架！").send(target=Target.group(str(group)))
+            await UniMessage.image(raw=image).send(target=Target.group(str(group)))
             groups_sent.append(int(group))
         except Exception as e:
             logger.error(f"NRC 商人提醒推送推送到群 {group} 失败: {e}")
 
+    msg_count = len(groups_sent) * (2 if hits else 1)
     return TaskRunResult(
         groups_sent=groups_sent,
-        messages_sent=len(groups_sent) * 2,
-        output_summary=f"nrc_merchant_alert → {hit_names} ({groups_sent})",
+        messages_sent=msg_count,
+        output_summary=f"nrc_merchant_alert → {hit_names or '无目标'} ({groups_sent})",
     )

--- a/plugins/clockwork/task_handlers.py
+++ b/plugins/clockwork/task_handlers.py
@@ -482,7 +482,7 @@ async def happy_new_year(**kwargs):
 
 
 async def nrc_merchant_alert(**kwargs):
-    """远行商人商品预警 - 每天8:00、12:00、16:00、20:00推送。
+    """远行商人商品提醒推送 - 每天8:00、12:00、16:00、20:00推送。
 
     检测目标商品是否上架，有则发提醒文本 + 货架图片，无则静默跳过。
     """
@@ -490,13 +490,13 @@ async def nrc_merchant_alert(**kwargs):
 
     data = await fetch_merchant_data()
     if not data:
-        logger.debug("NRC 商人预警：API 无数据")
+        logger.debug("NRC 商人提醒推送：API 无数据")
         return
 
     items = data.get("items", [])
     hits = [item for item in items if item.get("name") in ALERT_TARGET_ITEMS]
     if not hits:
-        logger.debug("NRC 商人预警：无目标商品上架，静默跳过")
+        logger.debug("NRC 商人提醒推送：无目标商品上架，静默跳过")
         return
 
     hit_names = "、".join(item["name"] for item in hits)
@@ -516,7 +516,7 @@ async def nrc_merchant_alert(**kwargs):
             await msg_img.send(target=Target.group(str(group)))
             groups_sent.append(int(group))
         except Exception as e:
-            logger.error(f"NRC 商人预警推送到群 {group} 失败: {e}")
+            logger.error(f"NRC 商人提醒推送推送到群 {group} 失败: {e}")
 
     return TaskRunResult(
         groups_sent=groups_sent,

--- a/plugins/clockwork/task_handlers.py
+++ b/plugins/clockwork/task_handlers.py
@@ -479,3 +479,47 @@ async def happy_new_year(**kwargs):
     group_list = await milky_bot.get_group_list()
     for group in group_list:
         await message.send(target=Target.group(str(group.group_id)))
+
+
+async def nrc_merchant_alert(**kwargs):
+    """远行商人商品预警 - 每天8:00、12:00、16:00、20:00推送。
+
+    检测目标商品是否上架，有则发提醒文本 + 货架图片，无则静默跳过。
+    """
+    from tools.NRCmerchant_current import ALERT_TARGET_ITEMS, _load_css, _render_html, fetch_merchant_data
+
+    data = await fetch_merchant_data()
+    if not data:
+        logger.debug("NRC 商人预警：API 无数据")
+        return
+
+    items = data.get("items", [])
+    hits = [item for item in items if item.get("name") in ALERT_TARGET_ITEMS]
+    if not hits:
+        logger.debug("NRC 商人预警：无目标商品上架，静默跳过")
+        return
+
+    hit_names = "、".join(item["name"] for item in hits)
+    alert_text = f"⚠️ 远行商人上架提醒：{hit_names} 已上架！"
+
+    html = _render_html(data)
+    css = _load_css()
+    image = await html_to_image(html, css=css, width=480)
+
+    msg_text = UniMessage.text(alert_text)
+    msg_img = UniMessage.image(raw=image)
+
+    groups_sent: list[int] = []
+    for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
+        try:
+            await msg_text.send(target=Target.group(str(group)))
+            await msg_img.send(target=Target.group(str(group)))
+            groups_sent.append(int(group))
+        except Exception as e:
+            logger.error(f"NRC 商人预警推送到群 {group} 失败: {e}")
+
+    return TaskRunResult(
+        groups_sent=groups_sent,
+        messages_sent=len(groups_sent) * 2,
+        output_summary=f"nrc_merchant_alert → {hit_names} ({groups_sent})",
+    )

--- a/plugins/clockwork/task_manager.py
+++ b/plugins/clockwork/task_manager.py
@@ -29,6 +29,7 @@ class TaskManager:
         "eq_cenc": "EARTHQUAKE_GROUP_ID",
         "eq_usgs": "EARTHQUAKE_GROUP_ID",
         "daily_news": "NEWS_SUMMARY_GROUP_ID",
+        "nrc_merchant_alert": "NRC_MERCHANT_GROUP_ID",
         "happy_new_year": None,  # 特殊处理：发送所有群
     }
 

--- a/templates/nrc_merchant.css
+++ b/templates/nrc_merchant.css
@@ -1,0 +1,249 @@
+@import url('https://font.sec.miui.com/font/css?family=MiSans:400,500,600,700,800,900:MiSans');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap');
+
+:root {
+    --surface: #ffffff;
+    --on-surface: #1a1c1e;
+    --on-surface-variant: #44474e;
+    --outline: #74777f;
+    --outline-variant: #c4c6cf;
+    --primary: #6750a4;
+    --secondary: #625b71;
+    --tertiary: #7d5260;
+    --background: #ffffff;
+    --gold-accent: #8a6d00;
+    --stack-sm: 8px;
+    --container-margin: 24px;
+    --stack-md: 16px;
+    --gutter: 16px;
+    --stack-lg: 32px;
+    --unit: 8px;
+    --font-display-xl: 900 48px/1.1 "MiSans", sans-serif;
+    --font-headline-lg: 800 32px/1.2 "MiSans", sans-serif;
+    --font-headline-lg-mobile: 800 28px/1.2 "MiSans", sans-serif;
+    --font-headline-md: 700 24px/1.3 "MiSans", sans-serif;
+    --font-body-lg: 400 18px/1.6 "MiSans", sans-serif;
+    --font-body-md: 400 16px/1.6 "MiSans", sans-serif;
+    --font-label-bold: 600 14px/1.4 "MiSans", sans-serif;
+    --font-label-sm: 500 12px/1.4 "MiSans", sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    background-color: var(--background);
+    color: var(--on-surface);
+    font-family: "MiSans", -apple-system, BlinkMacSystemFont, sans-serif;
+    -webkit-tap-highlight-color: transparent;
+    min-height: fit-content;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+#render-content {
+    width: 480px;
+    margin: 0 auto;
+    padding-bottom: 24px;
+}
+
+/* ── Top App Bar ── */
+
+.app-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 64px;
+    padding: 0 var(--container-margin);
+    background: var(--surface);
+    border-bottom: 1px solid #e1e2ec;
+    position: sticky;
+    top: 0;
+    z-index: 50;
+}
+
+.app-bar-title {
+    font: var(--font-headline-lg-mobile);
+    color: var(--on-surface);
+    letter-spacing: -0.02em;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+
+/* ── Main Content ── */
+
+.main-content {
+    padding: var(--stack-md) var(--container-margin) 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--stack-md);
+}
+
+/* ── Status Card ── */
+
+.status-card {
+    background: #f8f9ff;
+    border: 1px solid #e1e2ec;
+    border-radius: 1rem;
+    padding: var(--stack-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--stack-md);
+    overflow: hidden;
+}
+
+.status-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.status-date {
+    font: var(--font-headline-md);
+    color: var(--on-surface);
+}
+
+.status-round {
+    background: rgba(103, 80, 164, 0.1);
+    padding: 4px 12px;
+    border-radius: 9999px;
+    border: 1px solid rgba(103, 80, 164, 0.2);
+}
+
+.status-round-text {
+    font: var(--font-label-bold);
+    color: var(--primary);
+}
+
+.countdown-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: var(--surface);
+    border-radius: 1rem;
+    border: 1px solid #e1e2ec;
+}
+
+.countdown-label {
+    font: var(--font-label-sm);
+    color: var(--on-surface-variant);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 4px;
+}
+
+.countdown-time {
+    font: var(--font-display-xl);
+    color: var(--on-surface);
+    letter-spacing: -0.04em;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Product List ── */
+
+.product-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--stack-md);
+}
+
+.product-card {
+    display: flex;
+    gap: var(--stack-md);
+    align-items: center;
+    padding: 16px 0;
+    border-bottom: 1px solid #e1e2ec;
+    transition: background-color 0.15s;
+}
+
+.product-card:last-child { border-bottom: none; }
+
+.product-image-wrap {
+    position: relative;
+    flex-shrink: 0;
+    height: 96px;
+    width: 96px;
+}
+
+.product-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    padding: 8px;
+}
+
+.product-body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 6px;
+}
+
+.product-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.product-name {
+    font: 700 24px/1.2 "MiSans", sans-serif;
+    color: var(--on-surface);
+}
+
+.product-limit {
+    font: 600 18px/1.4 "MiSans", sans-serif;
+    color: var(--on-surface-variant);
+}
+
+.rarity-badge {
+    font: 700 16px/1.4 "MiSans", sans-serif;
+    padding: 5px 14px;
+    border-radius: 1rem;
+}
+
+.rarity-legendary {
+    background-color: rgba(245, 200, 64, 0.18);
+    color: var(--gold-accent);
+    border: 1px solid rgba(138, 109, 0, 0.25);
+}
+
+.rarity-rare {
+    background-color: rgba(192, 132, 252, 0.18);
+    color: #7c3aed;
+    border: 1px solid rgba(124, 58, 237, 0.25);
+}
+
+.rarity-common {
+    background-color: rgba(255, 255, 255, 0.06);
+    color: var(--on-surface-variant);
+    border: 1px solid #c4c6cf;
+}
+
+.price-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.currency-icon {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+}
+
+.price-text {
+    font: 700 24px/1.3 "Montserrat", "MiSans", sans-serif;
+    color: var(--on-surface);
+}
+
+/* ── Footer ── */
+
+.merchant-footer {
+    text-align: center;
+    padding: 12px 0 0;
+    font: var(--font-label-sm);
+    color: var(--outline);
+}

--- a/templates/nrc_merchant.html
+++ b/templates/nrc_merchant.html
@@ -1,0 +1,48 @@
+<!-- Top App Bar -->
+<header class="app-bar">
+    <h1 class="app-bar-title">
+        🛒 远行商人实时货架
+    </h1>
+</header>
+
+<div class="main-content">
+    <!-- Status Card -->
+    <section class="status-card">
+        <div class="status-top">
+            <span class="status-date">{{ slot_date }}</span>
+            <div class="status-round">
+                <span class="status-round-text">当前轮次 {{ round }} / {{ total_rounds }}</span>
+            </div>
+        </div>
+        <div class="countdown-box">
+            <span class="countdown-label">距离下轮刷新时间</span>
+            <span class="countdown-time">{{ countdown }}</span>
+        </div>
+    </section>
+
+    <!-- Product List -->
+    <div class="product-list">
+        {% for item in items %}
+        <div class="product-card">
+            <div class="product-image-wrap">
+                <img class="product-image" alt="{{ item.name }}" src="{{ item.image_full }}">
+            </div>
+            <div class="product-body">
+                <div class="product-row">
+                    <h3 class="product-name">{{ item.name }}</h3>
+                    <span class="rarity-badge rarity-{{ item.rarity }}">{{ item.rarity_cn }}</span>
+                </div>
+                <div class="product-row">
+                    <span class="product-limit">限购 {{ item.purchase_limit }}</span>
+                    <div class="price-row">
+                        <img class="currency-icon" alt="洛克贝" src="https://patchwiki.biligame.com/images/rocom/thumb/c/cf/h7k7nhpjbxp1o2yulg4xmjs595qctic.png/75px-%E7%89%A9%E5%93%81%E5%9B%BE%E6%A0%87_%E6%B4%9B%E5%85%8B%E8%B4%9D.png">
+                        <span class="price-text">{{ item.price_fmt }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <footer class="merchant-footer">更新于 {{ updated_at }}</footer>
+</div>

--- a/tools/NRCmerchant_current.py
+++ b/tools/NRCmerchant_current.py
@@ -36,7 +36,7 @@ _RARITY_CN = {
 
 httpx_client = get_http_client("nrc_merchant")
 
-# 预警目标商品名称
+# 提醒推送目标商品名称
 ALERT_TARGET_ITEMS = {"国王球", "棱镜球", "炫彩精灵蛋", "祝福项坠", "首领血脉秘药"}
 
 

--- a/tools/NRCmerchant_current.py
+++ b/tools/NRCmerchant_current.py
@@ -1,0 +1,145 @@
+"""远行商人（NRC Merchant）实时商品查询工具。
+
+API 数据 → Jinja2 模板渲染 HTML → Playwright 截图 → QQ 发送。
+"""
+
+import time
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+from langchain_core.tools import tool
+from nonebot import logger
+
+from utils.alconna import UniMessage
+from utils.http_client import get_http_client
+from utils.markdown_render import html_to_image
+
+API_URL = "https://roco-eggs.tsuki-world.com/api/merchant/current"
+IMAGE_BASE = "https://roco-eggs.tsuki-world.com"
+API_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://roco-eggs.tsuki-world.com/",
+    "Accept": "application/json",
+}
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+_RARITY_CN = {
+    "legendary": "极品",
+    "rare": "稀有",
+    "common": "普通",
+}
+
+httpx_client = get_http_client("nrc_merchant")
+
+# 预警目标商品名称
+ALERT_TARGET_ITEMS = {"国王球", "棱镜球", "炫彩精灵蛋", "祝福项坠", "首领血脉秘药"}
+
+
+async def fetch_merchant_data() -> dict | None:
+    """获取远行商人当前货架数据。失败返回 None。"""
+    try:
+        resp = await httpx_client.get(API_URL, headers=API_HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"NRC 商人 API 请求失败: {e}")
+        return None
+
+
+def _fmt_price(price: int) -> str:
+    """价格格式化：纯数字，无格式。"""
+    return str(price)
+
+
+def _fmt_countdown(remain: int) -> str:
+    """剩余秒数 → HH:MM:SS。"""
+    if remain <= 0:
+        return "00:00:00"
+    return f"{remain // 3600:02d}:{(remain % 3600) // 60:02d}:{remain % 60:02d}"
+
+
+def _build_items(items: list[dict]) -> list[dict]:
+    """将 API 返回的 items 转为模板所需字段。"""
+    result = []
+    for item in items:
+        rarity = item.get("rarity", "common")
+        img = item.get("image", "")
+        result.append({
+            "name": item.get("name", ""),
+            "image_full": IMAGE_BASE + img if (img and not img.startswith("http")) else img,
+            "purchase_limit": item.get("purchase_limit", 0),
+            "price_fmt": _fmt_price(item.get("price", 0)),
+            "rarity": rarity,
+            "rarity_cn": _RARITY_CN.get(rarity, "普通"),
+        })
+    return result
+
+
+def _render_html(data: dict) -> str:
+    """Jinja2 渲染：API 数据 → HTML 片段。"""
+    items = _build_items(data.get("items", []))
+    now = int(time.time())
+    countdown = _fmt_countdown(data.get("next_refresh_ts", now) - now)
+
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
+    template = env.get_template("nrc_merchant.html")
+    return template.render(
+        slot_date=data.get("slot_date", ""),
+        round=data.get("round", "?"),
+        total_rounds=data.get("total_rounds", "?"),
+        countdown=countdown,
+        items=items,
+        updated_at=data.get("updated_at", ""),
+    )
+
+
+def _load_css() -> str:
+    return (TEMPLATES_DIR / "nrc_merchant.css").read_text(encoding="utf-8")
+
+
+def _summary_text(data: dict) -> str:
+    """纯文本摘要，图片渲染失败时的降级输出。"""
+    items = data.get("items", [])
+    lines = [
+        f"远行商人 · {data.get('updated_at', '')} 更新",
+        f"当前第{data.get('round', '?')}轮 / 共{data.get('total_rounds', '?')}轮",
+    ]
+    for item in items:
+        name = item.get("name", "?")
+        price = _fmt_price(item.get("price", 0))
+        rarity = _RARITY_CN.get(item.get("rarity", "common"), "普通")
+        limit = item.get("purchase_limit", "?")
+        lines.append(f"  [{rarity}] {name} - {price}（限购{limit}）")
+    return "\n".join(lines)
+
+
+@tool(response_format="content_and_artifact")
+async def get_nrc_merchant_current() -> tuple[str, UniMessage | None]:
+    """获取洛克王国远行商人（NRC Merchant）当前商品货架。
+
+    触发关键词：远行商人、商人、NRC、今天商人卖什么、商人货架、商人商品
+
+    Returns:
+        tuple[str, UniMessage | None]: (文字摘要, 货架截图)
+    """
+    data = await fetch_merchant_data()
+    if data is None:
+        return "获取远行商人数据失败", None
+
+    if not data.get("items"):
+        return "远行商人暂无商品数据", None
+
+    try:
+        html = _render_html(data)
+        css = _load_css()
+        image = await html_to_image(html, css=css, width=480)
+        summary = _summary_text(data)
+        return summary, UniMessage.image(raw=image)
+    except Exception as e:
+        logger.error(f"NRC 商人渲染失败: {e}")
+        return _summary_text(data), None

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -37,6 +37,7 @@ _TOOL_MODULE_GROUPS = {
     "paint": "main",
     "video": "main",
     "memory": "memory",
+    "NRCmerchant_current": "main",
     "iching": "divination",
     "tarot": "divination",
 }

--- a/utils/configs.py
+++ b/utils/configs.py
@@ -111,6 +111,7 @@ class EnvConfig:
     EARTH_NOW_GROUP_ID: list = message.get("earth_now_group_id", [])
     NEWS_SUMMARY_GROUP_ID: list = message.get("news_summary_group_id", [])
     EARTHQUAKE_GROUP_ID: list = message.get("earthquake_group_id", [])
+    NRC_MERCHANT_GROUP_ID: list = message.get("nrc_merchant_group_id", [])
 
     QUERY_MESSAGE_NUMBERS: int = database["query_message_numbers"]
 
@@ -265,6 +266,7 @@ class EnvConfig:
         cls.EARTH_NOW_GROUP_ID = msg.get("earth_now_group_id", [])
         cls.NEWS_SUMMARY_GROUP_ID = msg.get("news_summary_group_id", [])
         cls.EARTHQUAKE_GROUP_ID = msg.get("earthquake_group_id", [])
+        cls.NRC_MERCHANT_GROUP_ID = msg.get("nrc_merchant_group_id", [])
 
         # ── 杂项 ──
         cls.QUERY_MESSAGE_NUMBERS = config.get("database", {}).get("query_message_numbers", cls.QUERY_MESSAGE_NUMBERS)


### PR DESCRIPTION
## 功能

### Agent 工具
- 新增 get_nrc_merchant_current 工具，用户自然语言触发
- API 数据 → Jinja2 模板渲染 HTML → Playwright 截图 → QQ 返图

### 定时提醒推送
- 每天 8:00 / 12:00 / 16:00 / 20:00 自动推送货架图片
- 国王球、棱镜球、炫彩精灵蛋、祝福项坠、首领血脉秘药上架时，额外推送文本提醒

### 文件变更
- tools/NRCmerchant_current.py — Agent 工具 + 公共函数
- templates/nrc_merchant.html + .css — 货架卡片模板
- tools/__init__.py — 工具注册
- plugins/clockwork/task_handlers.py — 定时推送 handler
- plugins/clockwork/__init__.py — 任务 auto-register
- plugins/clockwork/task_manager.py — 群组配置映射
- utils/configs.py + env.toml.example — 配置项

## 部署注意
需在 env.toml 的 [message] 段添加 nrc_merchant_group_id