### PR TITLE
远行商人：引入备用 API 源 + 时段内双 API 重试机制

### DIFF
--- a/plugins/clockwork/__init__.py
+++ b/plugins/clockwork/__init__.py
@@ -64,7 +64,7 @@ async def init_task_system():
     # 4. 同步群组配置到 EnvConfig
     await task_manager.initialize()
 
-    # 5. 注册 NRC 远行商人商品提醒推送（每天 8:15、12:15、16:15、20:15）
+    # 5. 注册 NRC 远行商人商品提醒推送（每天 8:10、12:10、16:10、20:10）
     try:
         await task_manager.register_task(
             job_id="nrc_merchant_alert",
@@ -72,7 +72,7 @@ async def init_task_system():
             handler_module="plugins.clockwork.task_handlers",
             handler_function="nrc_merchant_alert",
             trigger_type="cron",
-            trigger_args={"hour": "8,12,16,20", "minute": "15"},
+            trigger_args={"hour": "8,12,16,20", "minute": "10"},
             group_ids=EnvConfig.NRC_MERCHANT_GROUP_ID,
             description="每天定时检测远行商人是否上架目标商品（国王球、棱镜球、炫彩精灵蛋、祝福项坠、首领血脉秘药），有则推送提醒",
             metadata=ScheduledTaskMetadata(
@@ -86,7 +86,7 @@ async def init_task_system():
                 created_from="system",
             ),
         )
-        logger.info("NRC 远行商人商品提醒推送已注册（cron: 8,12,16,20:15 Asia/Shanghai）")
+        logger.info("NRC 远行商人商品提醒推送已注册（cron: 8,12,16,20:10 Asia/Shanghai）")
     except Exception as exc:
         logger.warning(f"注册 NRC 远行商人任务失败（可能已存在）: {exc}")
 

--- a/plugins/clockwork/task_handlers.py
+++ b/plugins/clockwork/task_handlers.py
@@ -556,7 +556,7 @@ async def nrc_merchant_alert(**kwargs):
             first_failure_notified = True
             for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
                 try:
-                    await UniMessage.text("当前已和访问到远行商人失去链接").send(
+                    await UniMessage.text("😭当前已和远行商人失去链接").send(
                         target=Target.group(str(group))
                     )
                 except Exception as e:

--- a/plugins/clockwork/task_handlers.py
+++ b/plugins/clockwork/task_handlers.py
@@ -481,40 +481,96 @@ async def happy_new_year(**kwargs):
 
 
 async def nrc_merchant_alert(**kwargs):
-    """远行商人商品提醒推送 - 每天8:00、12:00、16:00、20:00推送。
+    """远行商人商品提醒推送 - 每天8:10、12:10、16:10、20:10触发首次访问。
 
-    每次推送货架图片；检测到目标商品上架时，先发提醒文本再发图片。
+    每个时段（4小时）内若两个 API 均返回无效商品数据，每30分钟重试直至时段结束。
+    首次判定双 API 均无效时向配置群发送失联提示，后续重试失败静默。
     """
-    from tools.NRCmerchant_current import ALERT_TARGET_ITEMS, _load_css, _render_html, fetch_merchant_data
+    from tools.NRCmerchant_current import (
+        ALERT_TARGET_ITEMS,
+        _load_css,
+        _render_html,
+        fetch_merchant_data_with_fallback,
+    )
 
-    data = await fetch_merchant_data()
-    if not data:
-        logger.debug("NRC 商人提醒推送：API 无数据")
+    tz = zoneinfo.ZoneInfo("Asia/Shanghai")
+    now = datetime.datetime.now(tz)
+
+    period_starts = [8, 12, 16, 20]
+    current_hour = now.hour
+    period_end_hour = None
+    for h in period_starts:
+        if h <= current_hour < h + 4:
+            period_end_hour = h + 4
+            break
+
+    if period_end_hour is None:
+        logger.debug(f"NRC 商人提醒：当前时间 {now.strftime('%H:%M')} 不在任何推送时段内")
         return
 
-    items = data.get("items", [])
-    hits = [item for item in items if item.get("name") in ALERT_TARGET_ITEMS]
-    hit_names = "、".join(item["name"] for item in hits) if hits else ""
+    if period_end_hour == 24:
+        period_end = now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1)
+    else:
+        period_end = now.replace(hour=period_end_hour, minute=0, second=0, microsecond=0)
 
-    html = _render_html(data)
-    css = _load_css()
-    image = await html_to_image(html, css=css, width=480)
+    first_failure_notified = False
 
-    groups_sent: list[int] = []
-    for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
-        try:
-            if hits:
-                await UniMessage.text(f"⚠️ 远行商人上架提醒：{hit_names} 已上架！").send(
-                    target=Target.group(str(group))
-                )
-            await UniMessage.image(raw=image).send(target=Target.group(str(group)))
-            groups_sent.append(int(group))
-        except Exception as e:
-            logger.error(f"NRC 商人提醒推送推送到群 {group} 失败: {e}")
+    while True:
+        now = datetime.datetime.now(tz)
+        if now >= period_end:
+            logger.debug(f"NRC 商人提醒：已超出时段 {period_end.strftime('%H:%M')}，停止重试")
+            break
 
-    msg_count = len(groups_sent) * (2 if hits else 1)
-    return TaskRunResult(
-        groups_sent=groups_sent,
-        messages_sent=msg_count,
-        output_summary=f"nrc_merchant_alert → {hit_names or '无目标'} ({groups_sent})",
-    )
+        data, source = await fetch_merchant_data_with_fallback()
+
+        if data and data.get("items"):
+            items = data.get("items", [])
+            hits = [item for item in items if item.get("name") in ALERT_TARGET_ITEMS]
+            hit_names = "、".join(item["name"] for item in hits) if hits else ""
+
+            html = _render_html(data)
+            css = _load_css()
+            image = await html_to_image(html, css=css, width=480)
+
+            groups_sent: list[int] = []
+            for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
+                try:
+                    if hits:
+                        await UniMessage.text(f"⚠️ 远行商人上架提醒：{hit_names} 已上架！").send(
+                            target=Target.group(str(group))
+                        )
+                    await UniMessage.image(raw=image).send(target=Target.group(str(group)))
+                    groups_sent.append(int(group))
+                except Exception as e:
+                    logger.error(f"NRC 商人提醒推送到群 {group} 失败: {e}")
+
+            msg_count = len(groups_sent) * (2 if hits else 1)
+            return TaskRunResult(
+                groups_sent=groups_sent,
+                messages_sent=msg_count,
+                output_summary=f"nrc_merchant_alert [{source}] → {hit_names or '无目标'} ({groups_sent})",
+            )
+
+        # 双 API 均无效
+        if not first_failure_notified:
+            first_failure_notified = True
+            for group in EnvConfig.NRC_MERCHANT_GROUP_ID:
+                try:
+                    await UniMessage.text("当前已和访问到远行商人失去链接").send(
+                        target=Target.group(str(group))
+                    )
+                except Exception as e:
+                    logger.error(f"NRC 商人失联消息推送到群 {group} 失败: {e}")
+
+        next_retry = datetime.datetime.now(tz) + datetime.timedelta(minutes=30)
+        if next_retry >= period_end:
+            logger.debug(
+                f"NRC 商人提醒：下次重试 {next_retry.strftime('%H:%M')} 超出时段 {period_end.strftime('%H:%M')}，停止"
+            )
+            break
+
+        logger.info(
+            f"NRC 商人提醒：30分钟后重试 "
+            f"(当前 {datetime.datetime.now(tz).strftime('%H:%M:%S')}, 时段结束 {period_end.strftime('%H:%M')})"
+        )
+        await asyncio.sleep(30 * 60)

--- a/tools/NRCmerchant_current.py
+++ b/tools/NRCmerchant_current.py
@@ -3,7 +3,9 @@
 API 数据 → Jinja2 模板渲染 HTML → Playwright 截图 → QQ 发送。
 """
 
+import datetime as dt
 import time
+import zoneinfo
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -15,6 +17,7 @@ from utils.http_client import get_http_client
 from utils.markdown_render import html_to_image
 
 API_URL = "https://roco-eggs.tsuki-world.com/api/merchant/current"
+BACKUP_API_URL = "https://rocokingdomworld.org/api/merchant/live"
 IMAGE_BASE = "https://roco-eggs.tsuki-world.com"
 API_HEADERS = {
     "User-Agent": (
@@ -25,6 +28,7 @@ API_HEADERS = {
     "Referer": "https://roco-eggs.tsuki-world.com/",
     "Accept": "application/json",
 }
+_TZ_SHANGHAI = zoneinfo.ZoneInfo("Asia/Shanghai")
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
 
@@ -41,14 +45,110 @@ ALERT_TARGET_ITEMS = {"国王球", "棱镜球", "炫彩精灵蛋", "祝福项坠
 
 
 async def fetch_merchant_data() -> dict | None:
-    """获取远行商人当前货架数据。失败返回 None。"""
+    """获取远行商人当前货架数据（主 API）。失败返回 None。"""
     try:
         resp = await httpx_client.get(API_URL, headers=API_HEADERS)
         resp.raise_for_status()
         return resp.json()
     except Exception as e:
-        logger.error(f"NRC 商人 API 请求失败: {e}")
+        logger.error(f"NRC 商人主 API 请求失败: {e}")
         return None
+
+
+async def fetch_backup_merchant_data() -> dict | None:
+    """获取远行商人当前货架数据（备用 API）。失败返回 None。"""
+    try:
+        resp = await httpx_client.get(BACKUP_API_URL, headers=API_HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"NRC 商人备用 API 请求失败: {e}")
+        return None
+
+
+def _safe_int(value, default=0) -> int:
+    """安全转换为整数，失败返回默认值。"""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _adapt_backup_data(data: dict) -> dict:
+    """将备用 API 返回数据转换为主 API 格式，复用现有渲染管道。"""
+    # nextRefreshBeijing 字符串 → unix 时间戳
+    next_refresh_str = data.get("nextRefreshBeijing", "")
+    next_refresh_ts = int(time.time())
+    if next_refresh_str:
+        try:
+            parsed = dt.datetime.strptime(next_refresh_str, "%Y-%m-%d %H:%M:%S")
+            parsed = parsed.replace(tzinfo=_TZ_SHANGHAI)
+            next_refresh_ts = int(parsed.timestamp())
+        except (ValueError, OSError) as e:
+            logger.warning(f"NRC 商人备用 API nextRefreshBeijing 解析失败: {e}")
+
+    # startedAtBeijing 日期部分 → slot_date
+    started_at = data.get("startedAtBeijing", "")
+    slot_date = started_at[:10] if started_at else ""
+
+    # rounds dict key 数量 → total_rounds
+    rounds_dict = data.get("rounds", {})
+    total_rounds = len(rounds_dict) if isinstance(rounds_dict, dict) and rounds_dict else 1
+
+    # 适配 items：rarity 统一为 common，用 _rarity_label 储存 category 展示文字
+    items = []
+    for item in data.get("items", []):
+        items.append({
+            "name": item.get("name", ""),
+            "price": _safe_int(item.get("price", 0)),
+            "purchase_limit": _safe_int(item.get("limit", 0)),
+            "image": item.get("image", ""),
+            "rarity": "common",
+            "_rarity_label": item.get("category", ""),
+        })
+
+    # fetchedAt ISO 8601 UTC → 北京时间可读字符串
+    fetched_at = data.get("fetchedAt", "")
+    updated_at = ""
+    if fetched_at:
+        try:
+            # "2026-07-06T10:31:33.660Z" → "2026-07-06 18:31:33"
+            dt_obj = dt.datetime.fromisoformat(fetched_at.replace("Z", "+00:00"))
+            dt_bj = dt_obj.astimezone(_TZ_SHANGHAI)
+            updated_at = dt_bj.strftime("%H:%M")
+        except (ValueError, OSError) as e:
+            logger.warning(f"NRC 商人备用 API fetchedAt 解析失败: {e}")
+            updated_at = fetched_at
+
+    return {
+        "slot_date": slot_date,
+        "round": data.get("round", 1),
+        "total_rounds": total_rounds,
+        "next_refresh_ts": next_refresh_ts,
+        "updated_at": updated_at,
+        "items": items,
+    }
+
+
+async def fetch_merchant_data_with_fallback() -> tuple[dict | None, str | None]:
+    """获取远行商人货架数据，主 API 无效时自动切备用。
+
+    Returns:
+        (data_dict, source) — source 为 "primary" 或 "backup"；两个 API 都无效时返回 (None, None)。
+    """
+    data = await fetch_merchant_data()
+    if data and data.get("items"):
+        return data, "primary"
+
+    logger.info("NRC 商人：主 API 数据无效，尝试备用 API")
+    backup_data = await fetch_backup_merchant_data()
+    if backup_data and backup_data.get("items"):
+        adapted = _adapt_backup_data(backup_data)
+        logger.info("NRC 商人：备用 API 数据适配成功")
+        return adapted, "backup"
+
+    logger.warning("NRC 商人：主、备 API 均无有效商品数据")
+    return None, None
 
 
 def _fmt_price(price: int) -> str:
@@ -64,7 +164,11 @@ def _fmt_countdown(remain: int) -> str:
 
 
 def _build_items(items: list[dict]) -> list[dict]:
-    """将 API 返回的 items 转为模板所需字段。"""
+    """将 API 返回的 items 转为模板所需字段。
+
+    备用 API 数据已在上层适配，携带 category 字段用于稀有度展示标签，
+    rarity 统一为 "common" 以使用灰色样式。
+    """
     result = []
     for item in items:
         rarity = item.get("rarity", "common")
@@ -76,7 +180,7 @@ def _build_items(items: list[dict]) -> list[dict]:
                 "purchase_limit": item.get("purchase_limit", 0),
                 "price_fmt": _fmt_price(item.get("price", 0)),
                 "rarity": rarity,
-                "rarity_cn": _RARITY_CN.get(rarity, "普通"),
+                "rarity_cn": item.get("_rarity_label") or _RARITY_CN.get(rarity, "普通"),
             }
         )
     return result
@@ -114,9 +218,9 @@ def _summary_text(data: dict) -> str:
     for item in items:
         name = item.get("name", "?")
         price = _fmt_price(item.get("price", 0))
-        rarity = _RARITY_CN.get(item.get("rarity", "common"), "普通")
+        rarity_label = item.get("_rarity_label") or _RARITY_CN.get(item.get("rarity", "common"), "普通")
         limit = item.get("purchase_limit", "?")
-        lines.append(f"  [{rarity}] {name} - {price}（限购{limit}）")
+        lines.append(f"  [{rarity_label}] {name} - {price}（限购{limit}）")
     return "\n".join(lines)
 
 
@@ -129,12 +233,9 @@ async def get_nrc_merchant_current() -> tuple[str, UniMessage | None]:
     Returns:
         tuple[str, UniMessage | None]: (文字摘要, 货架截图)
     """
-    data = await fetch_merchant_data()
+    data, _source = await fetch_merchant_data_with_fallback()
     if data is None:
-        return "获取远行商人数据失败", None
-
-    if not data.get("items"):
-        return "远行商人暂无商品数据", None
+        return "当前远行商人无有效商品数据，请稍后再试", None
 
     try:
         html = _render_html(data)


### PR DESCRIPTION
## 变更概要

1. **新增备用 API 支持**
  - 数据适配层：备用 API 字段格式转换为主 API 格式，复用现有渲染管道
   - 主 API items 无效时自动切换到备用 API

2. **双 API 重试循环**（`plugins/clockwork/task_handlers.py`）
   - 每时段首次访问在 :10 分触发，间隔 30 分钟重试
   - 时段定义：8:00-12:00 / 12:00-16:00 / 16:00-20:00 / 20:00-00:00
   - 双 API 首次判定全挂时向配置群发送失联提示，后续重试失败静默
   - 获取到有效数据后自动停止，特殊商品检测对主/备 API 均生效

3. **Cron 时间调整**（`plugins/clockwork/__init__.py`）
   - 分钟从 `15` 改为 `10`

## 行为变更

| 场景 | 之前 | 之后 |
|------|------|------|
| 主 API 无效 | 静默跳过 | 切备用 API，备用有效则推送 |
| 双 API 均无效 | 静默跳过 | 发失联提示，30 分钟后重试 |
| 成功获取后 | 无后续 | 该时段停止重试 |